### PR TITLE
Add honeypot field to increase bot solver resiliency

### DIFF
--- a/captcha/sortables.php
+++ b/captcha/sortables.php
@@ -474,6 +474,10 @@ class sortables extends \phpbb\captcha\plugins\qa
 		// Well how did the user sorted it
 		$options_left = $this->request->variable('sortables_options_left', array(0));
 		$options_right = $this->request->variable('sortables_options_right', array(0));
+		$honeypot = $this->request->variable('password', []);
+		if ($honeypot != []) {
+			return false;
+		}
 
 		// Make sure the didn't submitted more options then it should (like trying everything... left/right: options ^ 2 )
 		if ($this->total_options === count($options_left) + count($options_right))

--- a/styles/prosilver/template/captcha_sortables.html
+++ b/styles/prosilver/template/captcha_sortables.html
@@ -72,6 +72,7 @@
 			<div id="sortables_options_right"></div>
 		</dd>
 	</dl>
+	<input type="text" name="password" style="display:none !important" tabindex="-1" autocomplete="new-password">
 
 <!-- IF S_TYPE == 1 -->
 	</fieldset>


### PR DESCRIPTION
We have used this Captcha plugin successfully for a month or so before spambots started to pass it, even with fairly complex questions and extremely limited retry attempt allowances.
After adding some logging, it seems that solvers simply "bruteforce" the questions until they find the right answers and then store them so they can circumvent them in the future.

A very simple and highly successful improvement was noticed when we added a simple honeypot. Our logging then showed almost all bot attempts would be caught by the honeypot.