### PR TITLE
Set minimal PHP version to 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 			"role": "Developer"
 		}],
 	"require": {
-		"php": ">=7.2.0",
+		"php": ">=8.0.0",
 		"composer/installers": "^1.0 || ^2.0"
 	},
 	"extra": {


### PR DESCRIPTION
Fixing Scruntinizer CI: Could not find a version of package phpbb/phpbb matching your minimum-stability (stable). Require it with an explicit version constraint allowing its desired stability.